### PR TITLE
Ensure home page title update on save

### DIFF
--- a/src/Builder/ESRI.ArcGIS.Mapping.Builder.Server/SaveSiteRequestHandlerBase.cs
+++ b/src/Builder/ESRI.ArcGIS.Mapping.Builder.Server/SaveSiteRequestHandlerBase.cs
@@ -22,11 +22,12 @@ namespace ESRI.ArcGIS.Mapping.Builder.Server
             XmlDocument xDoc = new XmlDocument();
             xDoc.Load(Request.InputStream);
             XmlElement rootElem = xDoc.DocumentElement;
+            string siteTitle = rootElem.GetAttribute("Title");
             
             SitePublishInfo info = Utils.GetSitePublishInfoFromXml(rootElem);
             try
             {
-                SaveSite(siteId, info);
+                SaveSite(siteId, siteTitle, info);
             }
             catch (Exception ex)
             {
@@ -34,6 +35,6 @@ namespace ESRI.ArcGIS.Mapping.Builder.Server
             }
         }
 
-        protected abstract void SaveSite(string siteId, SitePublishInfo info);
+        protected abstract void SaveSite(string siteId, string newTitle, SitePublishInfo info);
     }
 }

--- a/src/Builder/ESRI.ArcGIS.Mapping.Builder.Web/Code/ApplicationBuilder/ApplicationBuilderHelper.cs
+++ b/src/Builder/ESRI.ArcGIS.Mapping.Builder.Web/Code/ApplicationBuilder/ApplicationBuilderHelper.cs
@@ -53,15 +53,6 @@ namespace ESRI.ArcGIS.Mapping.Builder.Web
                 Fault.Message = "Unable to copy website files " + status;
                 return false;
             }
-
-            // Apply app title to index.htm
-            var path = Path.Combine(targetSite.PhysicalPath, "index.htm");
-            var html = File.ReadAllText(path);
-            var encodedName = HttpUtility.HtmlEncode(targetSite.Title);
-            var defaultTitle = string.Format("<title>{0}</title>", Strings._ArcGISViewerForMicrosoftSilverlight_);
-            var newTitle = string.Format("<title>{0}</title>", encodedName);
-            html = html.Replace(defaultTitle, newTitle);
-            File.WriteAllText(path, html);
             
             return true;
         }
@@ -141,7 +132,7 @@ namespace ESRI.ArcGIS.Mapping.Builder.Web
             return true;
         }
 
-        public bool SaveConfigurationForSite(Site site, SitePublishInfo info, out FaultContract Fault)
+        public bool SaveConfigurationForSite(Site site, SitePublishInfo info, out FaultContract Fault, string newTitle = null)
         {
             Fault = null;
 
@@ -297,6 +288,35 @@ namespace ESRI.ArcGIS.Mapping.Builder.Web
 
             // Save a preview image
             PreviewImageManager.SavePreviewImageForSite(site.ID, info.PreviewImageBytes);
+
+            // Apply app title to index.htm
+
+            // Get path of home page
+            path = Path.Combine(site.PhysicalPath, "index.htm");
+            if (File.Exists(path)) // make sure it exists
+            {
+                var updateTitle = newTitle != null; // Check whether title needs to be updated or is being specified for the first time
+
+                // Determine title to be replaced and title to replace it with
+                var titleToReplace = updateTitle ? site.Title : Strings._ArcGISViewerForMicrosoftSilverlight_;
+                var replacementTitle = updateTitle ? newTitle : site.Title;
+
+                // HTML-encode new title
+                replacementTitle = HttpUtility.HtmlEncode(replacementTitle); 
+
+                // Format titles as HTML title elements
+                var currentTitleElement = string.Format("<title>{0}</title>", titleToReplace);
+                var newTitleElement = string.Format("<title>{0}</title>", replacementTitle);
+
+                // Get HTML for home page 
+                var html = File.ReadAllText(path);
+
+                // Insert title
+                html = html.Replace(currentTitleElement, newTitleElement);
+
+                // Save home page
+                File.WriteAllText(path, html);
+            }
 
             return true;
         }

--- a/src/Builder/ESRI.ArcGIS.Mapping.Builder.Web/Code/ServiceHandlers/SaveSiteRequestHandler.cs
+++ b/src/Builder/ESRI.ArcGIS.Mapping.Builder.Web/Code/ServiceHandlers/SaveSiteRequestHandler.cs
@@ -15,15 +15,21 @@ namespace ESRI.ArcGIS.Mapping.Builder.Web
 {
     public class SaveSiteRequestHandler : SaveSiteRequestHandlerBase
     {
-        protected override void SaveSite(string siteId, SitePublishInfo info)
+        protected override void SaveSite(string siteId, string newTitle, SitePublishInfo info)
         {
             Site site = SiteConfiguration.FindExistingSiteByID(siteId);
             if (site == null)
                 throw new Exception("Unable to find site with siteId = " + siteId);
 
             FaultContract Fault = null;
-            if (!(new ApplicationBuilderHelper()).SaveConfigurationForSite(site, info, out Fault))
+            if (!(new ApplicationBuilderHelper()).SaveConfigurationForSite(site, info, out Fault, newTitle))
                 throw new Exception(Fault != null ? Fault.Message : "Unable to save site");
+
+            if (!string.IsNullOrEmpty(newTitle) && site.Title != newTitle) // Update site's title in site configuration list
+            {
+                site.Title = newTitle;
+                SiteConfiguration.SaveSite(site);
+            }
         }
     }
 }

--- a/src/Builder/ESRI.ArcGIS.Mapping.Builder/Commands/SaveApplicationCommand.cs
+++ b/src/Builder/ESRI.ArcGIS.Mapping.Builder/Commands/SaveApplicationCommand.cs
@@ -78,9 +78,11 @@ namespace ESRI.ArcGIS.Mapping.Builder
                     PreviewImageBytes = previewImageBytes,
                     ToolsXml = toolsXml,
                 };
-                ApplicationBuilderClient client = WCFProxyFactory.CreateApplicationBuilderProxy();
+                var title = "";
+                if (ViewerApplicationControl.Instance != null && ViewerApplicationControl.Instance.ViewerApplication != null)
+                    title = ViewerApplicationControl.Instance.ViewerApplication.TitleText; ApplicationBuilderClient client = WCFProxyFactory.CreateApplicationBuilderProxy();
                 client.SaveConfigurationForSiteCompleted += new EventHandler<SaveConfigurationForSiteCompletedEventArgs>(client_SaveConfigurationForSiteCompleted);
-                client.SaveConfigurationForSiteAsync(BuilderApplication.Instance.CurrentSite.ID, info);
+                client.SaveConfigurationForSiteAsync(BuilderApplication.Instance.CurrentSite.ID, info, title);
             }
         }
 

--- a/src/Builder/ESRI.ArcGIS.Mapping.Builder/Service/ApplicationBuilder/ApplicationBuilderClient.cs
+++ b/src/Builder/ESRI.ArcGIS.Mapping.Builder/Service/ApplicationBuilder/ApplicationBuilderClient.cs
@@ -311,11 +311,12 @@ namespace ESRI.ArcGIS.Mapping.Builder.ApplicationBuilder
         #endregion
 
         #region SaveConfiguration
-        public void SaveConfigurationForSiteAsync(string siteId, SitePublishInfo info, object userState = null)
+        public void SaveConfigurationForSiteAsync(string siteId, SitePublishInfo info, string siteTitle, object userState = null)
         {
             XDocument xDoc = new XDocument();
             XElement rootElem = new XElement("SaveApplication");
             xDoc.Add(rootElem);
+            rootElem.SetAttributeValue("Title", siteTitle);
 
             serializeSitePublishInfo(info, rootElem);
 


### PR DESCRIPTION
Addresses #11.  Moves updating of home page title from app creation to saving app configuration.  Modifies app save methods to include title as a parameter.
